### PR TITLE
[CMSP-606] PHP 8.3 compatibility

### DIFF
--- a/.bin/cleanup.sh
+++ b/.bin/cleanup.sh
@@ -3,7 +3,7 @@ set -ex
 
 # Nuke any lingering multidev environments from orbit.
 for ENV in $(terminus multidev:list --field=Name --format=list "$TERMINUS_SITE"); do
-  if [[ "$ENV" == ci-"$BUILD_NUM"-"$PHP_VERSION" || "$ENV" == localtests || "$ENV" == fs-* ]]; then
+  if [[ "$ENV" == ci-* || "$ENV" == localtests || "$ENV" == fs-* ]]; then
 	terminus multidev:delete --delete-branch --yes "${TERMINUS_SITE}"."${ENV}"
   fi
 done

--- a/.bin/cleanup.sh
+++ b/.bin/cleanup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -ex
-
+PHP_VERSION=$(echo "$PHP_VERSION" | tr -d '.')
 # Nuke any lingering multidev environments from orbit.
 for ENV in $(terminus multidev:list --field=Name --format=list "$TERMINUS_SITE"); do
   if [[ "$ENV" =~ ^ci-.*-"$PHP_VERSION" || "$ENV" == localtests || "$ENV" =~ ^fs-.*-"$PHP_VERSION" ]]; then

--- a/.bin/cleanup.sh
+++ b/.bin/cleanup.sh
@@ -4,6 +4,9 @@ set -ex
 # Nuke any lingering multidev environments from orbit.
 for ENV in $(terminus multidev:list --field=Name --format=list "$TERMINUS_SITE"); do
   if [[ "$ENV" == ci-* || "$ENV" == localtests || "$ENV" == fs-* ]]; then
-	terminus multidev:delete --delete-branch --yes "${TERMINUS_SITE}"."${ENV}"
+    echo "Deleting $ENV."
+	  terminus multidev:delete --delete-branch --yes "${TERMINUS_SITE}"."${ENV}"
   fi
 done
+
+echo "✅ Done!"

--- a/.bin/cleanup.sh
+++ b/.bin/cleanup.sh
@@ -3,7 +3,7 @@ set -ex
 
 # Nuke any lingering multidev environments from orbit.
 for ENV in $(terminus multidev:list --field=Name --format=list "$TERMINUS_SITE"); do
-  if [[ "$ENV" == ci-"$BUILD_NUM" || "$ENV" == localtests || "$ENV" == fs-* ]]; then
+  if [[ "$ENV" == ci-"$BUILD_NUM"-"$PHP_VERSION" || "$ENV" == localtests || "$ENV" == fs-* ]]; then
 	terminus multidev:delete --delete-branch --yes "${TERMINUS_SITE}"."${ENV}"
   fi
 done

--- a/.bin/cleanup.sh
+++ b/.bin/cleanup.sh
@@ -3,7 +3,7 @@ set -ex
 
 # Nuke any lingering multidev environments from orbit.
 for ENV in $(terminus multidev:list --field=Name --format=list "$TERMINUS_SITE"); do
-  if [[ "$ENV" == ci-* || "$ENV" == localtests || "$ENV" == fs-* ]]; then
+  if [[ "$ENV" =~ ^ci-.*-"$PHP_VERSION" || "$ENV" == localtests || "$ENV" =~ ^fs-.*-"$PHP_VERSION" ]]; then
     echo "Deleting $ENV."
 	  terminus multidev:delete --delete-branch --yes "${TERMINUS_SITE}"."${ENV}"
   fi

--- a/.bin/setup.sh
+++ b/.bin/setup.sh
@@ -47,7 +47,4 @@ echo "When PHP 8.3 is available on the platform, we will update the pantheon.yml
 
 terminus wp "$TERMINUS_SITE"."$FS_TEST" -- plugin install hello-dolly
 
-export FS_TEST
-export CI_TEST
-
 echo "✅ Done setting up $PHP_VER environments!"

--- a/.bin/setup.sh
+++ b/.bin/setup.sh
@@ -47,4 +47,7 @@ echo "When PHP 8.3 is available on the platform, we will update the pantheon.yml
 
 terminus wp "$TERMINUS_SITE"."$FS_TEST" -- plugin install hello-dolly
 
+export FS_TEST
+export CI_TEST
+
 echo "✅ Done setting up $PHP_VER environments!"

--- a/.bin/setup.sh
+++ b/.bin/setup.sh
@@ -3,7 +3,6 @@ set -e
 
 echo "Running PHP $PHP_VERSION tests..."
 
-TERMINUS_PLUGINS_DIR=.. terminus list -n remote
 PHP_VER="$PHP_VERSION"
 PHP_VERSION=$(echo "$PHP_VERSION" | tr -d '.')
 FS_TEST="fs-${BUILD_NUM}-${PHP_VERSION}"

--- a/.bin/setup.sh
+++ b/.bin/setup.sh
@@ -32,8 +32,8 @@ if [ ! -f ~/.ssh/config ]; then
 	chmod 600 ~/.ssh/config
 fi
 
+echo "Editing the ~/.ssh/config file"
 {
-	echo "Editing the ~/.ssh/config file"
 	echo "Host *"
 	echo "  StrictHostKeyChecking no"
 	echo "  LogLevel ERROR"

--- a/.bin/setup.sh
+++ b/.bin/setup.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+echo "Running PHP $PHP_VERSION tests..."
+
 TERMINUS_PLUGINS_DIR=.. terminus list -n remote
 PHP_VERSION=$(echo "$PHP_VERSION" | tr -d '.')
 FS_TEST="fs-${BUILD_NUM}-${PHP_VERSION}"

--- a/.bin/setup.sh
+++ b/.bin/setup.sh
@@ -4,6 +4,7 @@ set -e
 TERMINUS_PLUGINS_DIR=.. terminus list -n remote
 PHP_VERSION=$(echo "$PHP_VERSION" | tr -d '.')
 FS_TEST="fs-${BUILD_NUM}-${PHP_VERSION}"
+CI_TEST="ci-${BUILD_NUM}-${PHP_VERSION}"
 
 # Update Terminus to the latest version.
 terminus self:update
@@ -11,8 +12,8 @@ terminus self:update
 echo "Logging in with a machine token:"
 terminus auth:login -n --machine-token="$TERMINUS_TOKEN"
 terminus whoami
-terminus multidev:create "$TERMINUS_SITE".dev ci-"$BUILD_NUM"
-terminus connection:set "$TERMINUS_SITE".ci-"$BUILD_NUM" git
+terminus multidev:create "$TERMINUS_SITE".dev "$CI_TEST"
+terminus connection:set "$TERMINUS_SITE"."$CI_TEST" git
 # Set up the environment for filesystem tests.
 terminus multidev:create "$TERMINUS_SITE".dev "$FS_TEST"
 terminus connection:set "$TERMINUS_SITE"."$FS_TEST" sftp

--- a/.bin/setup.sh
+++ b/.bin/setup.sh
@@ -15,11 +15,13 @@ terminus self:update
 echo "Logging in with a machine token:"
 terminus auth:login -n --machine-token="$TERMINUS_TOKEN"
 terminus whoami
+echo "Creating multidev environments for testing."
 terminus multidev:create "$TERMINUS_SITE".dev "$CI_TEST"
 terminus connection:set "$TERMINUS_SITE"."$CI_TEST" git
 # Set up the environment for filesystem tests.
 terminus multidev:create "$TERMINUS_SITE".dev "$FS_TEST"
 terminus connection:set "$TERMINUS_SITE"."$FS_TEST" sftp
+echo "✅ Created $CI_TEST and $FS_TEST."
 
 # Check if ~/.ssh directory exists
 if [ ! -d ~/.ssh ]; then
@@ -40,7 +42,10 @@ echo "Editing the ~/.ssh/config file"
 	echo "  LogLevel ERROR"
 	echo "  UserKnownHostsFile /dev/null"
 } >> ~/.ssh/config
+echo "✅ Done!"
 
 echo "When PHP 8.3 is available on the platform, we will update the pantheon.yml to set the multidev environment to $PHP_VER to validate that the command runs on the platform with the approprate PHP version. For now, we're only running the command on whatever PHP version the fixture site is running."
 
 terminus wp "$TERMINUS_SITE"."$FS_TEST" -- plugin install hello-dolly
+
+echo "✅ Done setting up environments!"

--- a/.bin/setup.sh
+++ b/.bin/setup.sh
@@ -4,6 +4,7 @@ set -e
 echo "Running PHP $PHP_VERSION tests..."
 
 TERMINUS_PLUGINS_DIR=.. terminus list -n remote
+PHP_VER="$PHP_VERSION"
 PHP_VERSION=$(echo "$PHP_VERSION" | tr -d '.')
 FS_TEST="fs-${BUILD_NUM}-${PHP_VERSION}"
 CI_TEST="ci-${BUILD_NUM}-${PHP_VERSION}"
@@ -39,5 +40,7 @@ echo "Editing the ~/.ssh/config file"
 	echo "  LogLevel ERROR"
 	echo "  UserKnownHostsFile /dev/null"
 } >> ~/.ssh/config
+
+echo "When PHP 8.3 is available on the platform, we will update the pantheon.yml to set the multidev environment to $PHP_VER to validate that the command runs on the platform with the approprate PHP version. For now, we're only running the command on whatever PHP version the fixture site is running."
 
 terminus wp "$TERMINUS_SITE"."$FS_TEST" -- plugin install hello-dolly

--- a/.bin/setup.sh
+++ b/.bin/setup.sh
@@ -2,16 +2,11 @@
 set -e
 
 TERMINUS_PLUGINS_DIR=.. terminus list -n remote
+PHP_VERSION=$(echo "$PHP_VERSION" | tr -d '.')
+FS_TEST="fs-${BUILD_NUM}-${PHP_VERSION}"
 
 # Update Terminus to the latest version.
 terminus self:update
-
-# Set the fs-test number. If the build number is > 999, we need to trim the -test- out of the middle.
-if [ "$BUILD_NUM" -gt 999 ]; then
-	FS_TEST="fs-${BUILD_NUM}"
-else
-	FS_TEST="fs-test-${BUILD_NUM}"
-fi
 
 echo "Logging in with a machine token:"
 terminus auth:login -n --machine-token="$TERMINUS_TOKEN"

--- a/.bin/setup.sh
+++ b/.bin/setup.sh
@@ -47,4 +47,4 @@ echo "When PHP 8.3 is available on the platform, we will update the pantheon.yml
 
 terminus wp "$TERMINUS_SITE"."$FS_TEST" -- plugin install hello-dolly
 
-echo "✅ Done setting up environments!"
+echo "✅ Done setting up $PHP_VER environments!"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,10 +6,17 @@ jobs:
   phpcompatibility:
     runs-on: ubuntu-latest
     name: PHP Compatibility
+    strategy:
+      matrix:
+        php-version: [7.4, 8.3]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
       - name: PHPCompatibility
         uses: pantheon-systems/phpcompatibility-action@v1
         with:
-          test-versions: 7.4-
+          test-versions: ${{ matrix.php-version }}-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
         php-version: [7.4, 8.3]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,6 +60,8 @@ jobs:
             composer update
           fi
           composer install
+      - name: Install BATS
+        uses: mig4/setup-bats@v1
       - name: Functional Tests
         run: composer functional
       - name: Cleanup

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,15 +8,23 @@ env:
 jobs:
   unit:
     runs-on: ubuntu-latest
-    container:
-      image: quay.io/pantheon-public/terminus-plugin-test:4.x-php8.0
-      options: --user root
+    strategy:
+      matrix:
+        php: [7.4, 8.3]
     name: Unit Tests
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
       - name: Install Dependencies
-        run: composer install
+        run: |
+          if [[ "${{ matrix.php }}" == "7.4" ]]; then
+            composer update
+          fi
+          composer install
       - name: Unit Tests
         run: composer test
   terminus-3:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,6 +63,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Install Dependencies
-        run: composer install
+        run: |
+          if [[ "${{ matrix.php }}" == "7.4" ]]; then
+            composer update
+          fi
+          composer install
       - name: Code Style
         run: composer lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,9 +22,9 @@ jobs:
   terminus-3:
     needs: unit
     runs-on: ubuntu-latest
-    container:
-      image: quay.io/pantheon-public/terminus-plugin-test:4.x-php8.0
-      options: --user root
+    strategy:
+      matrix:
+        php: [7.4, 8.3]
     name: Terminus 3 Functional Tests
     env:
       TERMINUS_SITE: terminus-addons-installer-plugin
@@ -33,6 +33,18 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+      - name: Install Terminus
+        run: |
+          echo "💻 Installing Terminus from phar on Linux..."
+          curl -L "https://github.com/pantheon-systems/terminus/releases/latest/download/terminus.phar" -o terminus
+          chmod +x terminus
+          sudo mv terminus /usr/local/bin/
+          # Test that terminus works...
+          terminus --version          
       - name: Install SSH key
         uses: webfactory/ssh-agent@d4b9b8ff72958532804b70bbe600ad43b36d5f2e
         with:
@@ -43,6 +55,9 @@ jobs:
       - name: Install plugin
         run: |
           terminus self:plugin:install ${GITHUB_WORKSPACE}
+          if [[ "${{ matrix.php }}" == "7.4" ]]; then
+            composer update
+          fi
           composer install
       - name: Functional Tests
         run: composer functional

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,9 +8,6 @@ env:
 jobs:
   unit:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        php: [7.4, 8.3]
     name: Unit Tests
     steps:
       - name: Checkout
@@ -18,12 +15,9 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ matrix.php }}
+          php-version: 8.3
       - name: Install Dependencies
         run: |
-          if [[ "${{ matrix.php }}" == "7.4" ]]; then
-            composer update
-          fi
           composer install
       - name: Unit Tests
         run: composer test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     name: Unit Tests
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install Dependencies
         run: composer install
       - name: Unit Tests
@@ -32,7 +32,7 @@ jobs:
       BUILD_NUM: ${{ github.run_number }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install SSH key
         uses: webfactory/ssh-agent@d4b9b8ff72958532804b70bbe600ad43b36d5f2e
         with:
@@ -61,7 +61,7 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install Dependencies
         run: composer install
       - name: Code Style

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,15 +50,19 @@ jobs:
         if: always()
         run: ./.bin/cleanup.sh
   code-style:
-    runs-on: ubuntu-latest
-    container:
-      image: quay.io/pantheon-public/terminus-plugin-test:4.x-php8.2
-      options: --user root
     name: Code Style
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php: [7.4, 8.3]
     steps:
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
       - name: Checkout
         uses: actions/checkout@v2
       - name: Install Dependencies
         run: composer install
       - name: Code Style
-        run: composer cs
+        run: composer lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,7 @@ jobs:
       TERMINUS_SITE: terminus-addons-installer-plugin
       TERMINUS_TOKEN: ${{ secrets.TERMINUS_TOKEN }}
       BUILD_NUM: ${{ github.run_number }}
+      PHP_VERSION: ${{ matrix.php }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,11 @@
     "scripts": {
         "cs": "phpcs --standard=PSR2 -n src",
         "cbf": "phpcbf --standard=PSR2 -n src",
-        "lint": "find src -name '*.php' -print0 | xargs -0 -n1 php -l",
+        "phplint": "find src -name '*.php' -print0 | xargs -0 -n1 php -l",
+        "lint": [
+            "@phplint",
+            "@cs"
+        ],
         "unit": "phpunit --colors=always tests",
         "functional": [
             "Composer\\Config::disableProcessTimeout",

--- a/composer.lock
+++ b/composer.lock
@@ -9,30 +9,30 @@
     "packages-dev": [
         {
             "name": "doctrine/instantiator",
-            "version": "1.5.0",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b"
+                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/0a0fa9780f5d4e507415a065172d26a98d02047b",
-                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
+                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1 || ^8.0"
+                "php": "^8.1"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^9 || ^11",
+                "doctrine/coding-standard": "^11",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpbench/phpbench": "^0.16 || ^1",
-                "phpstan/phpstan": "^1.4",
-                "phpstan/phpstan-phpunit": "^1",
-                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
-                "vimeo/psalm": "^4.30 || ^5.4"
+                "phpbench/phpbench": "^1.2",
+                "phpstan/phpstan": "^1.9.4",
+                "phpstan/phpstan-phpunit": "^1.3",
+                "phpunit/phpunit": "^9.5.27",
+                "vimeo/psalm": "^5.4"
             },
             "type": "library",
             "autoload": {
@@ -59,7 +59,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/instantiator/issues",
-                "source": "https://github.com/doctrine/instantiator/tree/1.5.0"
+                "source": "https://github.com/doctrine/instantiator/tree/2.0.0"
             },
             "funding": [
                 {
@@ -75,7 +75,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-12-30T00:15:36+00:00"
+            "time": "2022-12-30T00:23:10+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -138,16 +138,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.16.0",
+            "version": "v4.17.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "19526a33fb561ef417e822e85f08a00db4059c17"
+                "reference": "a6303e50c90c355c7eeee2c4a8b27fe8dc8fef1d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/19526a33fb561ef417e822e85f08a00db4059c17",
-                "reference": "19526a33fb561ef417e822e85f08a00db4059c17",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/a6303e50c90c355c7eeee2c4a8b27fe8dc8fef1d",
+                "reference": "a6303e50c90c355c7eeee2c4a8b27fe8dc8fef1d",
                 "shasum": ""
             },
             "require": {
@@ -188,9 +188,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.16.0"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.17.1"
             },
-            "time": "2023-06-25T14:52:30+00:00"
+            "time": "2023-08-13T19:53:39+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -305,16 +305,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.26",
+            "version": "9.2.29",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "443bc6912c9bd5b409254a40f4b0f4ced7c80ea1"
+                "reference": "6a3a87ac2bbe33b25042753df8195ba4aa534c76"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/443bc6912c9bd5b409254a40f4b0f4ced7c80ea1",
-                "reference": "443bc6912c9bd5b409254a40f4b0f4ced7c80ea1",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/6a3a87ac2bbe33b25042753df8195ba4aa534c76",
+                "reference": "6a3a87ac2bbe33b25042753df8195ba4aa534c76",
                 "shasum": ""
             },
             "require": {
@@ -370,7 +370,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.26"
+                "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.29"
             },
             "funding": [
                 {
@@ -378,7 +379,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-03-06T12:58:08+00:00"
+            "time": "2023-09-19T04:57:46+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -623,16 +624,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.10",
+            "version": "9.6.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "a6d351645c3fe5a30f5e86be6577d946af65a328"
+                "reference": "f3d767f7f9e191eab4189abe41ab37797e30b1be"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/a6d351645c3fe5a30f5e86be6577d946af65a328",
-                "reference": "a6d351645c3fe5a30f5e86be6577d946af65a328",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/f3d767f7f9e191eab4189abe41ab37797e30b1be",
+                "reference": "f3d767f7f9e191eab4189abe41ab37797e30b1be",
                 "shasum": ""
             },
             "require": {
@@ -647,7 +648,7 @@
                 "phar-io/manifest": "^2.0.3",
                 "phar-io/version": "^3.0.2",
                 "php": ">=7.3",
-                "phpunit/php-code-coverage": "^9.2.13",
+                "phpunit/php-code-coverage": "^9.2.28",
                 "phpunit/php-file-iterator": "^3.0.5",
                 "phpunit/php-invoker": "^3.1.1",
                 "phpunit/php-text-template": "^2.0.3",
@@ -706,7 +707,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.10"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.13"
             },
             "funding": [
                 {
@@ -722,7 +723,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-07-10T04:04:23+00:00"
+            "time": "2023-09-19T05:39:22+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -1230,16 +1231,16 @@
         },
         {
             "name": "sebastian/global-state",
-            "version": "5.0.5",
+            "version": "5.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "0ca8db5a5fc9c8646244e629625ac486fa286bf2"
+                "reference": "bde739e7565280bda77be70044ac1047bc007e34"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/0ca8db5a5fc9c8646244e629625ac486fa286bf2",
-                "reference": "0ca8db5a5fc9c8646244e629625ac486fa286bf2",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bde739e7565280bda77be70044ac1047bc007e34",
+                "reference": "bde739e7565280bda77be70044ac1047bc007e34",
                 "shasum": ""
             },
             "require": {
@@ -1282,7 +1283,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.5"
+                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.6"
             },
             "funding": [
                 {
@@ -1290,7 +1291,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-02-14T08:28:10+00:00"
+            "time": "2023-08-02T09:26:13+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
@@ -1747,25 +1748,25 @@
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.0.2",
+            "version": "v3.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "26954b3d62a6c5fd0ea8a2a00c0353a14978d05c"
+                "reference": "7c3aff79d10325257a001fcf92d991f24fc967cf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/26954b3d62a6c5fd0ea8a2a00c0353a14978d05c",
-                "reference": "26954b3d62a6c5fd0ea8a2a00c0353a14978d05c",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/7c3aff79d10325257a001fcf92d991f24fc967cf",
+                "reference": "7c3aff79d10325257a001fcf92d991f24fc967cf",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2"
+                "php": ">=8.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.0-dev"
+                    "dev-main": "3.4-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -1794,7 +1795,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.0.2"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.3.0"
             },
             "funding": [
                 {
@@ -1810,20 +1811,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-01-02T09:55:41+00:00"
+            "time": "2023-05-23T14:45:45+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.27.0",
+            "version": "v1.28.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "5bbc823adecdae860bb64756d639ecfec17b050a"
+                "reference": "ea208ce43cbb04af6867b4fdddb1bdbf84cc28cb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/5bbc823adecdae860bb64756d639ecfec17b050a",
-                "reference": "5bbc823adecdae860bb64756d639ecfec17b050a",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/ea208ce43cbb04af6867b4fdddb1bdbf84cc28cb",
+                "reference": "ea208ce43cbb04af6867b4fdddb1bdbf84cc28cb",
                 "shasum": ""
             },
             "require": {
@@ -1838,7 +1839,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.27-dev"
+                    "dev-main": "1.28-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -1876,7 +1877,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.27.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.28.0"
             },
             "funding": [
                 {
@@ -1892,7 +1893,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-11-03T14:55:06+00:00"
+            "time": "2023-01-26T09:26:14+00:00"
         },
         {
             "name": "symfony/yaml",
@@ -2027,5 +2028,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/tests/bin/run-tests.sh
+++ b/tests/bin/run-tests.sh
@@ -7,4 +7,5 @@ fi
 
 . "$source_path"
 
+echo "Running bats tests..."
 TERMINUS_PLUGINS_DIR=.. PATH=tools/bin:$PATH bats -p -t tests/functional

--- a/tests/bin/set-up-globals.sh
+++ b/tests/bin/set-up-globals.sh
@@ -71,9 +71,20 @@ if [ -z "$TERMINUS_SITE" ]; then
   switch_to_sftp_mode "$FS_TEST_ENV"
   install_hello_dolly "$FS_TEST_ENV"
 else
-  # Always use the multidev if in CI.
-  SITE_ENV="${TERMINUS_SITE}.ci-${BUILD_NUM}"
-  FS_TEST_ENV="${TERMINUS_SITE}.fs-test-${BUILD_NUM}"
+  # If FS_TEST is defined, set FS_TEST_ENV.
+  if [ -n "$FS_TEST" ]; then
+    FS_TEST_ENV="${TERMINUS_SITE}.${FS_TEST}"
+  else
+    FS_TEST_ENV="${TERMINUS_SITE}.fs-test-${BUILD_NUM}"
+  fi
+
+  # If CI_TEST is defined, set SITE_ENV.
+  if [ -n "$CI_TEST" ]; then
+    SITE_ENV="${TERMINUS_SITE}.${CI_TEST}"
+  else
+    SITE_ENV="${TERMINUS_SITE}.ci-${BUILD_NUM}"
+  fi
+
   echo "SITE_ENV is $SITE_ENV"
   echo "FS_TEST_ENV is $FS_TEST_ENV"
 fi

--- a/tests/bin/set-up-globals.sh
+++ b/tests/bin/set-up-globals.sh
@@ -71,17 +71,11 @@ if [ -z "$TERMINUS_SITE" ]; then
   switch_to_sftp_mode "$FS_TEST_ENV"
   install_hello_dolly "$FS_TEST_ENV"
 else
-  # If FS_TEST is defined, set FS_TEST_ENV.
-  if [ -n "$FS_TEST" ]; then
-    FS_TEST_ENV="${TERMINUS_SITE}.${FS_TEST}"
+  if [ -n "$PHP_VERSION" ]; then
+    FS_TEST_ENV="${TERMINUS_SITE}.fs-${BUILD_NUM}-${PHP_VERSION}"
+    SITE_ENV="${TERMINUS_SITE}.ci-${BUILD_NUM}-${PHP_VERSION}"
   else
     FS_TEST_ENV="${TERMINUS_SITE}.fs-test-${BUILD_NUM}"
-  fi
-
-  # If CI_TEST is defined, set SITE_ENV.
-  if [ -n "$CI_TEST" ]; then
-    SITE_ENV="${TERMINUS_SITE}.${CI_TEST}"
-  else
     SITE_ENV="${TERMINUS_SITE}.ci-${BUILD_NUM}"
   fi
 

--- a/tests/bin/set-up-globals.sh
+++ b/tests/bin/set-up-globals.sh
@@ -3,6 +3,7 @@ set -e
 
 # Trim the newline character from BUILD_NUM variable
 BUILD_NUM=$(echo "${BUILD_NUM}" | tr -d '\n')
+PHP_VERSION=$(echo "${PHP_VERSION}" | tr -d '.')
 
 create_multidev() {
   local site="$1"

--- a/tests/functional/1-addons-install-test.bats
+++ b/tests/functional/1-addons-install-test.bats
@@ -28,7 +28,7 @@ debug() {
 }
 
 @test "run addons-install:run command" {
-  run terminus install:run ${SITE_ENV} ocp
+  run debug terminus install:run ${SITE_ENV} ocp
   [[ $output == *"Attempting to run the ocp job"* ]]
   [ "$status" -eq 0 ]
 

--- a/tests/functional/1-addons-install-test.bats
+++ b/tests/functional/1-addons-install-test.bats
@@ -28,7 +28,7 @@ debug() {
 }
 
 @test "run addons-install:run command" {
-  debug terminus install:run ${SITE_ENV} ocp
+  run terminus install:run ${SITE_ENV} ocp
   [[ $output == *"Attempting to run the ocp job"* ]]
   [ "$status" -eq 0 ]
 

--- a/tests/functional/1-addons-install-test.bats
+++ b/tests/functional/1-addons-install-test.bats
@@ -28,7 +28,7 @@ debug() {
 }
 
 @test "run addons-install:run command" {
-  run debug terminus install:run ${SITE_ENV} ocp
+  debug terminus install:run ${SITE_ENV} ocp
   [[ $output == *"Attempting to run the ocp job"* ]]
   [ "$status" -eq 0 ]
 


### PR DESCRIPTION
This PR adds a PHP version matrix on the CS and functional tests. Follow-on work will include updating the pantheon.yml file with the specified PHP version in the matrix, but that will need to be done after PHP 8.3 is available to the platform.

In addition to tweaking the scripts to accomidate the PHP-version matrix, changes have been made to make the tests generally more verbose. Additionally, the container image has been changed to GitHub default images so we can change the version of PHP running on the containers.

Notably, the Unit Tests have not been updated to use a PHP matrix. This is because the tests use `str_contains` which is a PHP 8+ function. However, there, I've set the PHP version that the unit tests are run on to PHP 8.3 to flag any issues that might come with the updated PHP version in automation.

Because of how releases are managed (via the [Autotag Action](https://github.com/pantheon-systems/action-autotag)), merging this will create a release, but there's no user-facing code that's being changed, just tests.