### PR TITLE
Let Autotag do it's thing

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -7,6 +7,8 @@ jobs:
   tag-release:
     runs-on: ubuntu-latest
     name: Tag & Release
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
Autotag failing due to lack of permissions. This should resolve and give the bot write permission on this repository.