### PR TITLE
[CMSP-751] Remove TODO about changing the fixture PHP version

### DIFF
--- a/.bin/setup.sh
+++ b/.bin/setup.sh
@@ -3,7 +3,6 @@ set -e
 
 echo "Running PHP $PHP_VERSION tests..."
 
-PHP_VER="$PHP_VERSION"
 PHP_VERSION=$(echo "$PHP_VERSION" | tr -d '.')
 FS_TEST="fs-${BUILD_NUM}-${PHP_VERSION}"
 CI_TEST="ci-${BUILD_NUM}-${PHP_VERSION}"
@@ -42,8 +41,6 @@ echo "Editing the ~/.ssh/config file"
 	echo "  UserKnownHostsFile /dev/null"
 } >> ~/.ssh/config
 echo "✅ Done!"
-
-echo "When PHP 8.3 is available on the platform, we will update the pantheon.yml to set the multidev environment to $PHP_VER to validate that the command runs on the platform with the approprate PHP version. For now, we're only running the command on whatever PHP version the fixture site is running."
 
 terminus wp "$TERMINUS_SITE"."$FS_TEST" -- plugin install hello-dolly
 


### PR DESCRIPTION
It is not useful for this project to change the fixture site's PHP version for tests, instead that should be a function of the scaffold extensions project.

https://getpantheon.atlassian.net/browse/CCB-219
https://getpantheon.atlassian.net/browse/CMSP-751