### PR TITLE
Fix Composer 2.9 plugin installation failure

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,5 +42,10 @@
         "terminus": {
             "compatible-version": "^3.2 || ^4"
         }
+    },
+    "config": {
+        "audit": {
+            "block-insecure": false
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Adds `config.audit.block-insecure=false` to composer.json to prevent Composer 2.9 from blocking plugin installation due to transitive dependency security advisories

## Problem
Composer 2.9 introduced a new default behavior that blocks installation when any dependency has a security advisory. This causes `terminus self:plugin:install` to fail with errors like:

```
Root composer.json requires psy/psysh v0.12.9 (exact version match), found psy/psysh[v0.12.9] 
but these were not loaded, because they are affected by security advisories
```

## Solution
This matches the fix already applied to terminus core. The setting allows installation to proceed while still reporting advisories via `composer audit`.

## Test plan
- [ ] Verify JSON is valid: `python3 -m json.tool composer.json`
- [ ] Test plugin installation with Composer 2.9+