### PR TITLE
ci: bump actions off deprecated Node 20 runtime

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
         php-version: [7.4, 8.3]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -11,7 +11,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
       - name: Tag & Release

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     name: Unit Tests
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -32,7 +32,7 @@ jobs:
       PHP_VERSION: ${{ matrix.php }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -42,7 +42,7 @@ jobs:
         with:
           pantheon-machine-token: ${{ secrets.TERMINUS_TOKEN }}
       - name: Install SSH key
-        uses: webfactory/ssh-agent@d4b9b8ff72958532804b70bbe600ad43b36d5f2e
+        uses: webfactory/ssh-agent@e83874834305fe9a4a2997156cb26c5de65a8555 # v0.10.0
         with:
           ssh-private-key: ${{ secrets.SSH_KEY }}
           log-public-key: false
@@ -77,7 +77,7 @@ jobs:
       PHP_VERSION: ${{ matrix.php }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -88,7 +88,7 @@ jobs:
           pantheon-machine-token: ${{ secrets.TERMINUS_TOKEN }}
           terminus-version: 3.6.2
       - name: Install SSH key
-        uses: webfactory/ssh-agent@d4b9b8ff72958532804b70bbe600ad43b36d5f2e
+        uses: webfactory/ssh-agent@e83874834305fe9a4a2997156cb26c5de65a8555 # v0.10.0
         with:
           ssh-private-key: ${{ secrets.SSH_KEY }}
           log-public-key: false
@@ -120,7 +120,7 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Install Dependencies
         run: |
           if [[ "${{ matrix.php }}" == "7.4" ]]; then


### PR DESCRIPTION
Actions bumped to node24 releases:

- actions/checkout: v3/v4 → v6.0.3
- webfactory/ssh-agent: d4b9b8ff72958532804b70bbe600ad43b36d5f2e → v0.10.0

Dependabot config added for github-actions ecosystem (weekly updates, grouped).

**Not changed:**
- mig4/setup-bats@v1 — latest release still uses node12, no node24 version available

🤖